### PR TITLE
feat: restyle site with NeoRavit cyberpunk aesthetic

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,14 +1,24 @@
 @import "tailwindcss";
 
 :root {
-  --color-bg: #0d0b14;
-  --color-surface: #171420;
-  --color-surface-hover: #1f1a2c;
-  --color-border: #2c2740;
-  --color-text: #d8d4e0;
-  --color-text-muted: #8b849c;
-  --color-accent: #4ade80;
-  --color-accent-hover: #6ee89a;
+  /* NeoRavit cyberpunk palette (from channel graphics) */
+  --color-bg: #0a0c12;
+  --color-surface: #0d1119;
+  --color-surface-hover: #121a28;
+  --color-border: rgba(79, 195, 247, 0.18);
+  --color-border-strong: rgba(79, 195, 247, 0.4);
+  --color-text: #d8f0ff;
+  --color-text-muted: #8ba9bd;
+  --color-accent: #4fc3f7;
+  --color-accent-hover: #7fd4fa;
+
+  /* accent set */
+  --color-nr-cyan: #4fc3f7;
+  --color-nr-purple: #b478ff;
+  --color-nr-green: #50c878;
+  --color-nr-amber: #fab432;
+
+  --nr-grid: rgba(79, 195, 247, 0.04);
 }
 
 @theme inline {
@@ -16,15 +26,74 @@
   --color-surface: var(--color-surface);
   --color-surface-hover: var(--color-surface-hover);
   --color-border: var(--color-border);
+  --color-border-strong: var(--color-border-strong);
   --color-text: var(--color-text);
   --color-text-muted: var(--color-text-muted);
   --color-accent: var(--color-accent);
   --color-accent-hover: var(--color-accent-hover);
-  --font-sans: var(--font-inter);
+  --color-nr-cyan: var(--color-nr-cyan);
+  --color-nr-purple: var(--color-nr-purple);
+  --color-nr-green: var(--color-nr-green);
+  --color-nr-amber: var(--color-nr-amber);
+  --font-sans: var(--font-share-tech-mono);
   --font-mono: var(--font-share-tech-mono);
 }
 
 body {
   background: var(--color-bg);
   color: var(--color-text);
+  font-family: var(--font-share-tech-mono), ui-monospace, monospace;
+}
+
+/* Faint cyber grid overlay, fixed behind all content */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--nr-grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--nr-grid) 1px, transparent 1px);
+  background-size: 40px 40px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* Uppercase, letter-spaced "eyebrow" label above section headings */
+.nr-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.7rem;
+  line-height: 1;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.nr-eyebrow::before {
+  content: "";
+  width: 1.4rem;
+  height: 1px;
+  background: currentColor;
+  opacity: 0.6;
+}
+
+/* Bordered "node" panel — the core building block of the NeoRavit graphics */
+.nr-panel {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.nr-panel-hover:hover {
+  border-color: var(--color-border-strong);
+  box-shadow: 0 0 26px -8px rgba(79, 195, 247, 0.5);
+}
+
+/* Cyan text glow for headings/logo */
+.nr-glow {
+  text-shadow: 0 0 18px rgba(79, 195, 247, 0.35);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
     >
       <body className="min-h-full flex flex-col font-sans antialiased">
         <Navbar />
-        <main className="flex-1">{children}</main>
+        <main className="relative z-10 flex-1">{children}</main>
         <Footer />
       </body>
     </html>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -21,8 +21,12 @@ const links = [
 
 export default function Contact() {
   return (
-    <section id="contact" className="mx-auto max-w-5xl px-6 py-24 text-center">
-      <h2 className="font-mono text-2xl text-text sm:text-3xl">Contact</h2>
+    <section
+      id="contact"
+      className="mx-auto flex max-w-5xl flex-col items-center px-6 py-24 text-center"
+    >
+      <span className="nr-eyebrow mb-4">{"// establish uplink"}</span>
+      <h2 className="text-2xl text-text nr-glow sm:text-3xl">Contact</h2>
       <p className="mx-auto mt-4 max-w-xl text-text-muted">
         The best ways to reach me — feel free to say hello.
       </p>
@@ -33,7 +37,7 @@ export default function Contact() {
             href={href}
             target={href.startsWith("http") ? "_blank" : undefined}
             rel={href.startsWith("http") ? "noopener noreferrer" : undefined}
-            className="flex items-center gap-2 rounded border border-border px-5 py-3 text-text transition-colors hover:border-accent hover:text-accent"
+            className="nr-panel nr-panel-hover flex items-center gap-2 px-5 py-3 text-sm text-text hover:text-accent"
           >
             <Icon className="h-5 w-5" />
             {label}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,9 +6,10 @@ export default function Footer() {
 
   return (
     <footer className="border-t border-border">
-      <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 py-8 text-sm text-text-muted sm:flex-row sm:justify-between">
-        <p>
-          &copy; {year} {siteConfig.name}
+      <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 py-8 text-xs tracking-[0.15em] text-text-muted sm:flex-row sm:justify-between">
+        <p className="uppercase">
+          <span className="text-accent/50">&copy;</span> {year}{" "}
+          {siteConfig.name}
         </p>
         <div className="flex items-center gap-4">
           <a

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,8 +6,9 @@ export default function Hero() {
     <section id="about" className="mx-auto max-w-5xl px-6 py-24">
       <div className="flex flex-col items-center gap-12 md:flex-row">
         <div className="flex flex-col items-center text-center md:items-start md:text-left">
-          <h1 className="font-mono text-3xl font-medium text-text sm:text-4xl">
-            Hi, I&apos;m LeAnne.
+          <span className="nr-eyebrow mb-5">{"// system online"}</span>
+          <h1 className="text-3xl text-text nr-glow sm:text-4xl">
+            <span className="text-accent">&gt;</span> Hi, I&apos;m LeAnne.
           </h1>
           <p className="mt-6 max-w-xl leading-relaxed text-text-muted">
             I&apos;m a software engineer and master&apos;s student who used to
@@ -20,26 +21,29 @@ export default function Hero() {
           <div className="mt-8 flex flex-wrap justify-center gap-4">
             <a
               href="#contact"
-              className="rounded border border-accent px-6 py-2 text-accent transition-colors hover:bg-accent hover:text-bg"
+              className="border border-accent px-6 py-2 text-xs uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-bg"
             >
               Get in touch
             </a>
             <a
               href="#projects"
-              className="rounded border border-border px-6 py-2 text-text transition-colors hover:border-accent hover:text-accent"
+              className="border border-border px-6 py-2 text-xs uppercase tracking-[0.18em] text-text transition-colors hover:border-accent hover:text-accent"
             >
               See my work
             </a>
           </div>
         </div>
-        <Image
-          src="/images/profile/profilepic2.jpg"
-          alt={`Portrait of ${siteConfig.name}`}
-          width={256}
-          height={256}
-          priority
-          className="h-64 w-64 shrink-0 rounded-full border border-border object-cover"
-        />
+        <div className="relative shrink-0">
+          <div className="pointer-events-none absolute -inset-2 rounded-full bg-accent/15 blur-2xl" />
+          <Image
+            src="/images/profile/profilepic2.jpg"
+            alt={`Portrait of ${siteConfig.name}`}
+            width={256}
+            height={256}
+            priority
+            className="relative h-64 w-64 rounded-full border border-border-strong object-cover shadow-[0_0_40px_-8px_rgba(79,195,247,0.5)]"
+          />
+        </div>
       </div>
     </section>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,17 +11,21 @@ const links = [
 
 export default function Navbar() {
   return (
-    <header className="sticky top-0 z-20 border-b border-border bg-surface/90 backdrop-blur">
+    <header className="sticky top-0 z-20 border-b border-border bg-bg/80 backdrop-blur">
       <div className="mx-auto flex max-w-5xl flex-wrap items-center justify-between gap-4 px-6 py-4">
-        <Link href="#about" className="font-mono text-lg text-text">
-          {siteConfig.name}
+        <Link
+          href="#about"
+          className="group flex items-center gap-2 text-sm tracking-[0.2em] text-accent nr-glow"
+        >
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-accent" />
+          {siteConfig.name.toUpperCase()}
         </Link>
-        <nav className="flex flex-wrap items-center gap-6 text-sm">
+        <nav className="flex flex-wrap items-center gap-5 text-xs tracking-[0.18em]">
           {links.map((link) => (
             <a
               key={link.href}
               href={link.href}
-              className="text-text-muted transition-colors hover:text-accent"
+              className="uppercase text-text-muted transition-colors hover:text-accent"
             >
               {link.label}
             </a>

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -7,7 +7,7 @@ export default function ProjectCard({ project }: { project: Project }) {
       href={project.repoUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="group flex flex-col overflow-hidden rounded-lg border border-border bg-surface transition-colors hover:border-accent"
+      className="nr-panel nr-panel-hover group flex flex-col overflow-hidden"
     >
       <div className="relative aspect-video w-full overflow-hidden bg-bg">
         {project.media?.type === "image" ? (
@@ -40,7 +40,7 @@ export default function ProjectCard({ project }: { project: Project }) {
         )}
       </div>
       <div className="flex flex-1 flex-col gap-3 p-6">
-        <h3 className="font-mono text-lg text-text group-hover:text-accent">
+        <h3 className="text-lg text-text transition-colors group-hover:text-accent">
           {project.title}
         </h3>
         <p className="flex-1 text-sm leading-relaxed text-text-muted">
@@ -50,7 +50,7 @@ export default function ProjectCard({ project }: { project: Project }) {
           {project.tech.map((tag) => (
             <li
               key={tag}
-              className="rounded border border-border px-2 py-1 font-mono text-xs text-text-muted"
+              className="border border-border px-2 py-1 text-xs uppercase tracking-wider text-accent/80"
             >
               {tag}
             </li>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -5,8 +5,9 @@ export default function Projects() {
   return (
     <section id="projects" className="border-y border-border bg-surface/30">
       <div className="mx-auto max-w-5xl px-6 py-24">
-        <div className="mb-12 text-center">
-          <h2 className="font-mono text-2xl text-text sm:text-3xl">Projects</h2>
+        <div className="mb-12 flex flex-col items-center text-center">
+          <span className="nr-eyebrow mb-4">{"// build log"}</span>
+          <h2 className="text-2xl text-text nr-glow sm:text-3xl">Projects</h2>
           <p className="mx-auto mt-4 max-w-xl text-text-muted">
             A few things I&apos;ve been building lately.
           </p>

--- a/src/components/Resume.tsx
+++ b/src/components/Resume.tsx
@@ -3,8 +3,9 @@ import { siteConfig } from "@/data/site";
 export default function Resume() {
   return (
     <section id="resume" className="border-y border-border bg-surface/30">
-      <div className="mx-auto max-w-5xl px-6 py-24 text-center">
-        <h2 className="font-mono text-2xl text-text sm:text-3xl">Resume</h2>
+      <div className="mx-auto flex max-w-5xl flex-col items-center px-6 py-24 text-center">
+        <span className="nr-eyebrow mb-4">{"// credentials"}</span>
+        <h2 className="text-2xl text-text nr-glow sm:text-3xl">Resume</h2>
         <p className="mx-auto mt-4 max-w-xl text-text-muted">
           Download a copy of my resume for more detail on my background and
           experience.
@@ -13,7 +14,7 @@ export default function Resume() {
           href={siteConfig.resumeUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-8 inline-block rounded border border-accent px-6 py-2 font-mono text-accent transition-colors hover:bg-accent hover:text-bg"
+          className="mt-8 inline-block border border-accent px-6 py-2 text-xs uppercase tracking-[0.18em] text-accent transition-colors hover:bg-accent hover:text-bg"
         >
           View Resume
         </a>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,10 +1,18 @@
 import { skillGroups } from "@/data/skills";
 
+const accents = [
+  "text-nr-cyan",
+  "text-nr-purple",
+  "text-nr-green",
+  "text-nr-amber",
+] as const;
+
 export default function Skills() {
   return (
     <section id="skills" className="mx-auto max-w-5xl px-6 py-24">
-      <div className="mb-12 text-center">
-        <h2 className="font-mono text-2xl text-text sm:text-3xl">
+      <div className="mb-12 flex flex-col items-center text-center">
+        <span className="nr-eyebrow mb-4">{"// tech stack"}</span>
+        <h2 className="text-2xl text-text nr-glow sm:text-3xl">
           Skills &amp; Technologies
         </h2>
         <p className="mx-auto mt-4 max-w-xl text-text-muted">
@@ -12,17 +20,18 @@ export default function Skills() {
         </p>
       </div>
       <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-        {skillGroups.map((group) => (
-          <div
-            key={group.category}
-            className="rounded-lg border border-border bg-surface p-6"
-          >
-            <h3 className="font-mono text-sm text-accent">{group.category}</h3>
+        {skillGroups.map((group, i) => (
+          <div key={group.category} className="nr-panel nr-panel-hover p-6">
+            <h3
+              className={`text-sm uppercase tracking-[0.18em] ${accents[i % accents.length]}`}
+            >
+              {group.category}
+            </h3>
             <ul className="mt-4 flex flex-wrap gap-2">
               {group.items.map((item) => (
                 <li
                   key={item}
-                  className="rounded border border-border px-3 py-1 text-sm text-text"
+                  className="border border-border px-3 py-1 text-sm text-text"
                 >
                   {item}
                 </li>


### PR DESCRIPTION
Aligns the portfolio with the NeoRavit channel graphics: Share Tech Mono as the primary font, deep blue-black background with a faint cyan grid overlay, the cyan/purple/green/amber accent set, bordered 'node' panels with hover glow, and uppercase eyebrow labels across all sections (navbar, hero, projects, skills, resume, contact, footer).